### PR TITLE
BITEC-961 Adding support for Spark2.0 in jupiter notebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ RUN apt-get install -yq --force-yes --no-install-recommends build-essential pyth
  && pip3 install --upgrade py4j jupyter
 
 ### installing spark kernel for Jupyter notebook, remove this RUN if you do not need this feature.
-RUN wget https://s3-eu-west-1.amazonaws.com/zalando-spark/toree-kernel-0.1.0-SNAPSHOT.tar.gz -O /tmp/toree-kernel-0.1.0-SNAPSHOT.tar.gz \
- && tar zxf /tmp/toree-kernel-0.1.0-SNAPSHOT.tar.gz -C /opt \
- && rm  -rf /tmp/toree-kernel-0.1.0-SNAPSHOT.tar.gz
+RUN wget https://s3.eu-central-1.amazonaws.com/saiki-spark/toree-0.2.0.dev1-incubating-binary-release.tar.gz -O /tmp/toree-0.2.0.dev1-incubating-binary-release.tar.gz \
+ && tar zxf /tmp/toree-0.2.0.dev1-incubating-binary-release.tar.gz -C /opt \
+ && rm  -rf /tmp/toree-0.2.0.dev1-incubating-binary-release.tar.gz
+
 
 ### installing python libraries for data analyzing, remove this RUN if you do not need this feature.
 RUN pip3 install --upgrade numpy \

--- a/kernel.json
+++ b/kernel.json
@@ -1,14 +1,14 @@
 {
-    "display_name": "Spark 1.6.0 (Scala)",
+    "display_name": "Spark 2.0.0 (Scala)",
     "language_info": { "name": "scala" },
     "argv": [
-        "/opt/toree-kernel/bin/toree-kernel",
+        "/opt/toree/bin/run.sh",
         "--profile",
         "{connection_file}"
     ],
     "codemirror_mode": "scala",
     "env": {
-        "SPARK_OPTS": "--master=${SPARK_MASTER} --driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=info",
+        "SPARK_OPTS": "--master=${SPARK_MASTER} --driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=INFO",
         "MAX_INTERPRETER_THREADS": "16",
         "CAPTURE_STANDARD_OUT": "true",
         "CAPTURE_STANDARD_ERR": "true",


### PR DESCRIPTION
The previous Toree kernel 0.1 didn't support Spark2.0. With this a 0.2.0-dev version a Spark 2.0 support has been added. 