### PR TITLE
Docker Base image needs to be updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry.opensource.zalan.do/stups/python:3.4.0-4
-MAINTAINER Teng Qiu <teng.qiu@zalando.de>
+FROM registry.opensource.zalan.do/stups/python:3.5.2-38
+MAINTAINER Team Lago <team-lago@zalando.de>
 
 ENV SPARK_VERSION="2.0.1-SNAPSHOT" HADOOP_VERSION="2.7.2"
 ENV SPARK_PACKAGE="spark-${SPARK_VERSION}-bin-${HADOOP_VERSION}"


### PR DESCRIPTION
docker base image is super old. please update to the newest image:

https://registry.opensource.zalan.do/teams/stups/artifacts/python/tags
(current latest one is 3.5.2-38)

beware that the ubuntu base image was updated and you need to check if this still works with ubuntu 16.04